### PR TITLE
fix(catalyst): add context menu mirror of stream row swipe actions

### DIFF
--- a/ios/Clawline/Clawline/Views/Chat/StreamManagerSheet.swift
+++ b/ios/Clawline/Clawline/Views/Chat/StreamManagerSheet.swift
@@ -191,6 +191,24 @@ struct StreamManagerSheet: View {
                                 .disabled(!canPerformRemovalAction(for: stream))
                                 .tint(canPerformRemovalAction(for: stream) ? .red : Color.gray.opacity(0.35))
                             }
+                            .contextMenu {
+                                Button {
+                                    beginRenaming(stream)
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+                                .disabled(!canPerformRenameAction(for: stream))
+
+                                Button(role: .destructive) {
+                                    pendingRemovalStream = stream
+                                } label: {
+                                    Label(
+                                        removalActionTitle(for: stream),
+                                        systemImage: removalActionImage(for: stream)
+                                    )
+                                }
+                                .disabled(!canPerformRemovalAction(for: stream))
+                            }
                     }
 
                     ForEach(filteredPendingCreateRows) { pendingRow in


### PR DESCRIPTION
## Summary

On Mac Catalyst with a non-touch pointer (regular mouse), `.swipeActions` on the stream manager rows are unreachable — there's no built-in gesture translation, and SwiftUI doesn't auto-surface them as a right-click context menu in this build. The result is that mouse-only Catalyst users cannot rename or remove streams.

This adds a parallel `.contextMenu` on each stream row that mirrors the existing swipe actions (Rename + Remove). Behaviour:

- **Mac Catalyst (mouse):** right-click on a stream row reveals the actions.
- **Mac Catalyst (trackpad / Magic Mouse):** existing swipe gesture still works, plus right-click as a fallback.
- **iOS (iPhone/iPad):** swipe-left still works as before; long-press additionally reveals the same context menu. No regression to existing tap-to-select behaviour.

## Test plan

- [x] Built for Mac Catalyst (Debug, ad-hoc signed). Verified right-click on a stream row shows Rename + Remove. Clicking Rename swaps the row to the inline `TextField` and focus transfers correctly. Disabled states (e.g. while another row is being renamed) are honoured.
- [x] Built and installed on physical iPhone 16 Pro (iOS 26). Verified swipe-left still reveals the original pencil + remove icons. Long-press now shows the context menu. Tap still selects the stream. No visual or behavioural regression.
- [x] Ran the full test suite (`xcodebuild test -scheme Clawline -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`).
  - **Result:** 43 pre-existing assertion failures across `ChatFlowOrganicComplianceTests` (Bug T190 URL/markdown boundary detection) and `BubbleScrollTests` (Bug #62 truncated bubble inner scroll), plus 4 simulator crashes in the same areas during test runs. None of these touch `StreamManagerSheet` or stream row gesture code. Happy to share the full result bundle if useful.
  - I did not bisect `main` vs this branch to prove these are pre-existing, but the failing files and code paths are completely orthogonal to a view-only context-menu addition. Let me know if a `main`-baseline run is wanted before merging.

## CONTRIBUTING compliance — gaps disclosed

In the spirit of `CONTRIBUTING.md`:

- **No prior issue opened.** I treated this as a small, scoped follow-up rather than a "significant change" warranting prior discussion. Happy to file an issue retroactively if maintainers prefer.
- **No new tests added.** The change is view-only and mirrors existing action handlers (`beginRenaming`, `pendingRemovalStream`) whose business logic is already exercised by `ChatViewModel`-level tests. Gesture-level coverage would need snapshot or UI-test infrastructure beyond this PR's scope.
- **Screenshots not attached.** Will add on request — Mac Catalyst right-click menu and iPhone long-press menu both demonstrable.
- **Branch name** is `catalyst-stream-row-context-menu` rather than the `feature/` prefix the doc suggests. Used to match the prevailing `clawline-*`/topic-named pattern visible in the repo's actual branch list. Happy to rename.

## Notes

- One-line-style change, isolated to `StreamManagerSheet.swift`. No other gestures touched.
- This is the same gesture-translation gap that likely exists on other `.swipeActions` rows across the app; this PR fixes only the stream manager row for scope. Happy to follow up with a sweep if maintainers want it.